### PR TITLE
Initial 10.12 (12.0) support - prerelease

### DIFF
--- a/BuildScripts/Dockerfile
+++ b/BuildScripts/Dockerfile
@@ -1,5 +1,4 @@
-# ARG IMAGE_TAG=8
-ARG IMAGE_TAG=9
+ARG IMAGE_TAG=10
 FROM mcr.microsoft.com/dotnet/sdk:${IMAGE_TAG}.0
 
 RUN apt-get update -y && \

--- a/BuildScripts/build.sh
+++ b/BuildScripts/build.sh
@@ -1,30 +1,14 @@
 #!/bin/bash
 TAG=${1}
 
-
-#### V1 ####
-
-# if ! docker images -a | grep mcr.microsoft.com/dotnet/sdk${TAG}.0; then
-#     echo "Pulling dotnet:${TAG}.0 image"
-#     docker pull mcr.microsoft.com/dotnet/sdk:${TAG}.0
-# else
-#     echo "Image already exists!"
-# fi
-
-# docker run --name dotnet -it -v .:/Development mcr.microsoft.com/dotnet/sdk:${TAG}.0 /Development/BuildScripts/dotnetbuild.sh
-# docker rm dotnet
-
-#### V2 ####
 IMAGE="pypi_dotnet"
 echo "Using image: '${IMAGE}:${TAG}.0'"
 if ! docker images -a | grep "${IMAGE}" | grep "${TAG}.0"; then
     echo "Generating '${IMAGE}:${TAG}.0' image"
-    docker build -t ${IMAGE}:${TAG}.0 --build-arg IMAGE_TAG=9 ./BuildScripts/
+    docker build -t ${IMAGE}:${TAG}.0 --build-arg IMAGE_TAG=10 ./BuildScripts/
 else
     echo "Image already exists!"
 fi
 
 docker run --name dotnet -it -v .:/Development ${IMAGE}:${TAG}.0 /Development/BuildScripts/dotnetbuild.sh "${2}"
 docker rm dotnet
-
-# docker build -t pypi_dotnet:8.0 --build-arg IMAGE_TAG=8 .

--- a/Jellyfin.Plugin.Newsletters/Jellyfin.Plugin.Newsletters.csproj
+++ b/Jellyfin.Plugin.Newsletters/Jellyfin.Plugin.Newsletters.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Newsletters</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
@@ -11,17 +11,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
-    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SkiaSharp" Version="3.116.1" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.8" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.8" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="SkiaSharp" Version="3.119.2" />
     <PackageReference Include="SQLitePCL.pretty.netstandard" Version="3.1.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="SerilogAnalyzer" Version="0.15.0" PrivateAssets="All" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.376" PrivateAssets="All" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" Version="1.1.31" PrivateAssets="All" />
   </ItemGroup>
 

--- a/build.yaml
+++ b/build.yaml
@@ -2,9 +2,9 @@
 name: "Newsletters"
 guid: "60f478ab-2dd6-4ea0-af10-04d033f75979"
 imageUrl: "https://raw.githubusercontent.com/solidsnake1298/Jellyfin-Newsletter-Plugin/master/logo.png"
-version: "1.3.0.0"
-targetAbi: "10.11.0.0"
-framework: "net9.0"
+version: "1.3.1.0"
+targetAbi: "10.12.0.0"
+framework: "net10.0"
 overview: "Send newsletters for recently added media"
 description: "This plugin automacially scans a users library (default every 4 hours), populates a list of recently added (not previously scanned) media, converts that data into HTML format, and sends out emails to a provided list of recipients."
 category: "General"
@@ -13,5 +13,5 @@ artifacts:
   - "Jellyfin.Plugin.Newsletters.dll"
   - "SQLitePCL.pretty.dll"
 changelog: >
-  - Correctly parse files that contain multiple episodes.
+  - Added Jellyfin 10.12 support.
 FULL CHANGELOG: https://raw.githubusercontent.com/solidsnake1298/Jellyfin-Newsletter-Plugin/master/CHANGELOG.md


### PR DESCRIPTION
Initial 10.12 (12.0) support - prerelease

Rebuilt with dotnet 10, targeting Jellyfin 10.12 (12.0).

The latest versions for Jellyfin.Controller and Jellyfin.Model are 10.11.8.  Everything functions as expected, except for images.

`[ERR] Error generating image attachment.  Null image path?`